### PR TITLE
[ads-collector] Add CLI arguments for dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GOOGLEADS_CONFIG=google-ads.yaml
 GOOGLEADS_CUSTOMER_ID=<google customer id>
 ```
 
-Provide a Google Cloud service account JSON key and update the path in `run.py` if needed. You can also adjust `START_DATE` and `END_DATE` in the script to define the period to collect.
+Provide a Google Cloud service account JSON key and update the path in `run.py` if needed. Specify the collection period with the `--start-date` and `--end-date` arguments when running the script. Both default to today.
 
 ## Usage
 Install the dependencies and run the script:
@@ -39,7 +39,7 @@ Install the dependencies and run the script:
 ```
 pip install -r requirements.txt
 python migrate.py  # run once to create/update tables
-python run.py --providers meta,google
+python run.py --providers meta,google --start-date 2023-01-01 --end-date 2023-01-02
 ```
 
 The script will export `ads_data_<start>_to_<end>.csv` and `.xlsx` files, insert new rows into the configured MySQL table and append data to BigQuery.

--- a/run.py
+++ b/run.py
@@ -35,11 +35,11 @@ MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD")
 MYSQL_DATABASE = os.getenv("MYSQL_DATABASE")
 MYSQL_TABLE = os.getenv("MYSQL_TABLE", "ads_data")
 
-# Timeframe
-START_DATE = '2025-01-01'
-END_DATE = '2025-01-02'
-#END_DATE = date.today().isoformat()
-OUTPUT_CSV = f"ads_data_{START_DATE}_to_{END_DATE}"
+# Default timeframe
+TODAY = date.today().isoformat()
+START_DATE = TODAY
+END_DATE = TODAY
+OUTPUT_CSV = ""
 
 # Init API
 FacebookAdsApi.init(APP_ID, APP_SECRET, ACCESS_TOKEN)
@@ -246,8 +246,21 @@ if __name__ == '__main__':
         required=True,
         help="Comma separated list of ad providers (e.g. meta,google)",
     )
+    parser.add_argument(
+        "--start-date",
+        default=TODAY,
+        help="Start date in YYYY-MM-DD format (default: today)",
+    )
+    parser.add_argument(
+        "--end-date",
+        default=TODAY,
+        help="End date in YYYY-MM-DD format (default: today)",
+    )
     args = parser.parse_args()
     AD_PROVIDERS = [p.strip() for p in args.providers.split(',') if p.strip()]
+    START_DATE = args.start_date
+    END_DATE = args.end_date
+    OUTPUT_CSV = f"ads_data_{START_DATE}_to_{END_DATE}"
 
     print(
         f"Fetching ads data from {START_DATE} to {END_DATE} for {', '.join(AD_PROVIDERS)}..."


### PR DESCRIPTION
## Summary
- parse `--start-date` and `--end-date` arguments in `run.py`
- default to today's date when not provided
- update README usage instructions accordingly

## Testing
- `python -m py_compile run.py migrate.py`


------
https://chatgpt.com/codex/tasks/task_e_6859230b2e68832aba33bb94f1b2458a