### PR TITLE
[ads-collector] Add storage service abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ads Collector is a Python script that retrieves advertising insights from the Me
 - Iterates through a date range to fetch ad level metrics such as impressions, clicks and spend.
 - Handles API rate limits with an exponential backoff strategy.
 - Normalizes numeric fields and timestamps before saving.
-- Loads the final dataset into a BigQuery table and writes CSV/Excel copies locally.
+- Supports multiple storage backends (CSV, Excel, BigQuery, MySQL) configured via the `--storages` argument.
 - Stores the data in a MySQL table while skipping records that already exist. The table schema is managed via migrations.
 - Easily extendable to additional advertising providers.
 - Providers are implemented as classes in the `providers` package.
@@ -40,12 +40,11 @@ Install the dependencies and run the script:
 ```
 pip install -r requirements.txt
 python migrate.py  # run once to create/update tables
-python run.py --providers meta,google --start-date 2023-01-01 --end-date 2023-01-02
-```
+python run.py --providers meta,google --start-date 2023-01-01 --end-date 2023-01-02 --storages csv,excel,bigquery,mysql
 
 The names passed to `--providers` map to classes in the `providers` package.
 
-The script will export `ads_data_<start>_to_<end>.csv` and `.xlsx` files, insert new rows into the configured MySQL table and append data to BigQuery.
+The script saves results to the selected storage backends.
 
 ### Running MySQL with Docker Compose
 

--- a/storages/__init__.py
+++ b/storages/__init__.py
@@ -1,0 +1,21 @@
+from .base import BaseStorage
+from .csv_storage import CSVStorage
+from .excel import ExcelStorage
+from .bigquery import BigQueryStorage
+from .mysql import MySQLStorage
+
+STORAGE_CLASSES = {
+    CSVStorage.name: CSVStorage,
+    ExcelStorage.name: ExcelStorage,
+    BigQueryStorage.name: BigQueryStorage,
+    MySQLStorage.name: MySQLStorage,
+}
+
+__all__ = [
+    "BaseStorage",
+    "CSVStorage",
+    "ExcelStorage",
+    "BigQueryStorage",
+    "MySQLStorage",
+    "STORAGE_CLASSES",
+]

--- a/storages/base.py
+++ b/storages/base.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+
+class BaseStorage(ABC):
+    """Abstract base class for storage backends."""
+
+    name: str
+
+    @abstractmethod
+    def save(self, df, output_name: str) -> None:
+        """Persist dataframe. `output_name` is used as file base name."""
+        raise NotImplementedError

--- a/storages/bigquery.py
+++ b/storages/bigquery.py
@@ -1,0 +1,34 @@
+import os
+from google.cloud import bigquery
+
+from .base import BaseStorage
+
+
+class BigQueryStorage(BaseStorage):
+    name = "bigquery"
+
+    def __init__(self):
+        service_account_json = os.getenv("BG_SERVICE_ACCOUNT_JSON")
+        dataset = os.getenv("BQ_DATASET")
+        table = os.getenv("BQ_TABLE")
+        self.client = bigquery.Client.from_service_account_json(service_account_json)
+        self.table_ref = self.client.dataset(dataset).table(table)
+
+    def _generate_schema(self, df):
+        dtype_map = {
+            'int64': 'INTEGER',
+            'float64': 'FLOAT',
+            'bool': 'BOOLEAN',
+            'datetime64[ns]': 'DATE',
+            'object': 'STRING',
+        }
+        return [
+            bigquery.SchemaField(col, dtype_map.get(str(dtype), 'STRING'))
+            for col, dtype in df.dtypes.items()
+        ]
+
+    def save(self, df, output_name: str) -> None:
+        job_config = bigquery.LoadJobConfig(write_disposition="WRITE_APPEND")
+        job = self.client.load_table_from_dataframe(df, self.table_ref, job_config=job_config)
+        job.result()
+        print(f"Uploaded {len(df)} rows to BigQuery.")

--- a/storages/csv_storage.py
+++ b/storages/csv_storage.py
@@ -1,0 +1,9 @@
+from .base import BaseStorage
+
+
+class CSVStorage(BaseStorage):
+    name = "csv"
+
+    def save(self, df, output_name: str) -> None:
+        df.to_csv(f"{output_name}.csv", index=False)
+        print(f"Saved CSV to {output_name}.csv")

--- a/storages/excel.py
+++ b/storages/excel.py
@@ -1,0 +1,9 @@
+from .base import BaseStorage
+
+
+class ExcelStorage(BaseStorage):
+    name = "excel"
+
+    def save(self, df, output_name: str) -> None:
+        df.to_excel(f"{output_name}.xlsx", index=False)
+        print(f"Saved Excel to {output_name}.xlsx")

--- a/storages/mysql.py
+++ b/storages/mysql.py
@@ -1,0 +1,41 @@
+import os
+import mysql.connector
+
+from .base import BaseStorage
+
+
+class MySQLStorage(BaseStorage):
+    name = "mysql"
+
+    def __init__(self):
+        self.host = os.getenv("MYSQL_HOST")
+        self.user = os.getenv("MYSQL_USER")
+        self.password = os.getenv("MYSQL_PASSWORD")
+        self.database = os.getenv("MYSQL_DATABASE")
+        self.table = os.getenv("MYSQL_TABLE", "ads_data")
+
+    def save(self, df, output_name: str) -> None:
+        conn = mysql.connector.connect(
+            host=self.host,
+            user=self.user,
+            password=self.password,
+            database=self.database,
+        )
+        cursor = conn.cursor()
+        insert_query = f"""
+            INSERT IGNORE INTO {self.table} (
+                account_type, account_id, campaign_id, campaign_name,
+                adset_id, adset_name, ad_id, ad_name, spend,
+                impressions, clicks, date
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """
+        rows = df[[
+            'account_type', 'account_id', 'campaign_id', 'campaign_name',
+            'adset_id', 'adset_name', 'ad_id', 'ad_name', 'spend',
+            'impressions', 'clicks', 'date'
+        ]].values.tolist()
+        cursor.executemany(insert_query, rows)
+        conn.commit()
+        print(f"Uploaded {cursor.rowcount} rows to MySQL.")
+        cursor.close()
+        conn.close()


### PR DESCRIPTION
## Summary
- abstract storage backends into separate classes
- add CSV, Excel, BigQuery and MySQL storage implementations
- select active storage backends via new `--storages` argument
- update README with usage and feature notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a98a851b0832aa7988cbe3e7f438a