### PR TITLE
[ads-collector] Fix README usage and enable running src/run.py directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Install the dependencies and run the script:
 
 ```
 pip install -r requirements.txt
-python migrate.py  # run once to create/update tables
-python run.py --start-date 2023-01-01 --end-date 2023-01-02
+python src/migrate.py  # run once to create/update tables
+python src/run.py --start-date 2023-01-01 --end-date 2023-01-02
 ```
 
 Providers listed in `AD_PROVIDERS` map to classes in the `providers` package.

--- a/src/run.py
+++ b/src/run.py
@@ -1,8 +1,12 @@
 import os
+import sys
 import pandas as pd
 from datetime import date, datetime, timedelta
 from dotenv import load_dotenv
 import argparse
+
+# Ensure the project root is on the Python path when executing as a script
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.providers import PROVIDER_CLASSES
 from src.storages import STORAGE_CLASSES


### PR DESCRIPTION
## Summary
- fix usage instructions in README
- allow running src/run.py as script by adjusting Python path

## Testing
- `python src/run.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685aa2782154832a8a0e4f9dae8db3ff