### PR TITLE
[ads-collector] Add Dockerfile and docs for production container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+dist/
+venv/
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+COPY src src
+COPY migrations migrations
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["python", "src/run.py"]

--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ following defaults if a variable is not provided:
 - root password: `${MYSQL_ROOT_PASSWORD:-root}`
 
 Set matching values in your `.env` file so `src/run.py` can connect.
+
+### Building the Docker Image
+
+Build the production image using the provided `Dockerfile`:
+
+```bash
+docker build -t ads-collector .
+```
+
+Then run the container with your environment variables:
+
+```bash
+docker run --env-file .env ads-collector
+```
+
+The entrypoint applies database migrations before starting the collector.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+python src/migrate.py
+exec "$@"


### PR DESCRIPTION
## Summary
- create production Dockerfile with entrypoint
- add docker-entrypoint.sh script
- ignore development files in `.dockerignore`
- document how to build and run the container

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685aa5f845cc832ab283a95f4eb33ebe