### PR TITLE
[ads-collector] Add collector service to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ following defaults if a variable is not provided:
 
 Set matching values in your `.env` file so `src/run.py` can connect.
 
+### Running the Collector with Docker Compose
+
+The compose file also defines a `collector` service for local development.
+It builds the image from the Dockerfile, mounts the project directory and
+connects to the `mysql` container. Start the stack with:
+
+```bash
+docker compose up --build collector
+```
+
+The collector uses the environment variables from your `.env` file and
+automatically runs migrations before executing `src/run.py`.
+
 ### Building the Docker Image
 
 Build the production image using the provided `Dockerfile`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,15 @@ services:
       - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
+  collector:
+    build: .
+    env_file:
+      - .env
+    environment:
+      MYSQL_HOST: mysql
+    volumes:
+      - .:/app
+    depends_on:
+      - mysql
 volumes:
   mysql_data:


### PR DESCRIPTION
## Summary
- add `collector` service to `docker-compose.yml`
- document running the collector with Docker Compose

No tests to run per `AGENTS.md`.

------
https://chatgpt.com/codex/tasks/task_e_685ab3f0744c832a8f02d7914c18c531