### PR TITLE
[ads-collector] Add GHCR publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Build and publish image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ docker run --env-file .env ads-collector
 ```
 
 The entrypoint applies database migrations before starting the collector.
+
+### Continuous Deployment
+
+A GitHub Actions workflow builds and publishes the Docker image to GitHub Packages when changes are merged into the main branch. The image will be available at ghcr.io/<owner>/ads-collector.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and push Docker image to GitHub Packages
- document continuous deployment in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685abb780030832aa164420c8c743e8f