### PR TITLE
[ads-collector] Support fetching from multiple Meta ad accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ AD_PROVIDERS=meta,google
 
 # Meta Ads configuration
 META_ACCESS_TOKEN=
+# Optional: comma separated list of ad account IDs.
+# If empty, all accounts accessible to the token will be used.
 META_AD_ACCOUNT_ID=
 META_APP_ID=
 META_APP_SECRET=

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ads Collector is a Python script that retrieves advertising insights from the Me
 - Loads environment variables from a `.env` file using `python-dotenv`.
 - Logs progress and errors to stdout using Python's `logging` module.
 - Providers are implemented as classes in the `providers` package.
+- Automatically collects data from all Meta ad accounts available to the token, or a subset specified via `META_AD_ACCOUNT_ID`.
 
 ## Configuration
 Copy `.env.example` to `.env` and fill in your credentials. The example file lists

--- a/src/providers/meta.py
+++ b/src/providers/meta.py
@@ -12,51 +12,61 @@ class MetaProvider(BaseProvider):
 
     def __init__(self):
         self.access_token = os.getenv("META_ACCESS_TOKEN")
-        self.ad_account_id = os.getenv("META_AD_ACCOUNT_ID")
+        account_ids_env = os.getenv("META_AD_ACCOUNT_ID")
         self.app_id = os.getenv("META_APP_ID")
         self.app_secret = os.getenv("META_APP_SECRET")
         self.logger = logging.getLogger(__name__)
         FacebookAdsApi.init(self.app_id, self.app_secret, self.access_token)
+        if account_ids_env:
+            self.ad_account_ids = [a.strip() for a in account_ids_env.split(",") if a.strip()]
+        else:
+            from facebook_business.adobjects.user import User
+            user = User(fbid="me")
+            accounts = safe_api_call(lambda: user.get_ad_accounts(fields=[AdAccount.Field.id]))
+            self.ad_account_ids = [acc[AdAccount.Field.id] for acc in accounts]
 
     def fetch_data(self, start_date, end_date):
-        account = AdAccount(self.ad_account_id)
         data = []
 
-        for current_date in get_dates_between(start_date, end_date):
-            params = {
-                "time_range": {
-                    "since": current_date.isoformat(),
-                    "until": current_date.isoformat(),
-                },
-                "level": "ad",
-                "fields": [
-                    "account_id",
-                    "campaign_id",
-                    "campaign_name",
-                    "adset_id",
-                    "adset_name",
-                    "ad_id",
-                    "ad_name",
-                    "spend",
-                    "impressions",
-                    "clicks",
-                    "date_start",
-                    "date_stop",
-                ],
-                "limit": 1000,
-            }
+        for account_id in self.ad_account_ids:
+            account = AdAccount(account_id)
 
-            def get_data():
-                return account.get_insights(params=params)
-            self.logger.info(
-                "Fetching data for ad account %s, date %s",
-                self.ad_account_id,
-                current_date.isoformat(),
-            )
-            insights = safe_api_call(get_data)
-            while True:
-                data += insights
-                if not insights.load_next_page():
-                    break
+            for current_date in get_dates_between(start_date, end_date):
+                params = {
+                    "time_range": {
+                        "since": current_date.isoformat(),
+                        "until": current_date.isoformat(),
+                    },
+                    "level": "ad",
+                    "fields": [
+                        "account_id",
+                        "campaign_id",
+                        "campaign_name",
+                        "adset_id",
+                        "adset_name",
+                        "ad_id",
+                        "ad_name",
+                        "spend",
+                        "impressions",
+                        "clicks",
+                        "date_start",
+                        "date_stop",
+                    ],
+                    "limit": 1000,
+                }
+
+                def get_data():
+                    return account.get_insights(params=params)
+
+                self.logger.info(
+                    "Fetching data for ad account %s, date %s",
+                    account_id,
+                    current_date.isoformat(),
+                )
+                insights = safe_api_call(get_data)
+                while True:
+                    data += insights
+                    if not insights.load_next_page():
+                        break
 
         return data


### PR DESCRIPTION
## Summary
- allow listing several Meta Ad Account IDs
- fall back to automatic discovery of accessible accounts
- document the new behaviour in README and `.env.example`

## Testing
- `flake8 || true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872267ba570832a88ea9425737b6ec5